### PR TITLE
Sidebar with recursive categories

### DIFF
--- a/snippets/_sidebar.liquid
+++ b/snippets/_sidebar.liquid
@@ -12,7 +12,10 @@
   
   {% if category.children.size != 0 %}
     {% assign categories = category.children %}
-    {% include 'sidebar' %}
+    
+    <ul class="children_list"> 
+      {% include 'sidebar' %}
+    </ul>
   {% endif %}
   
 {% endfor %}

--- a/snippets/_sidebar.liquid
+++ b/snippets/_sidebar.liquid
@@ -1,25 +1,18 @@
-<div id="taxonomies" class="sidebar-item">
-  <h1>Catálogo</h1>
+{% for category in categories %}
 
-  {% unless categories.size == 0 %}
-  <ul class="navigation-list">
-    <li><h5>Categorías</h5>
-      <ul>
-      {% for category in categories %}
-        <li {% if current_category.id == category.id %} class="current root" {% else %} class="root" {% endif %}>
-          <a href="{{ category.url }}" title="Categoría: {{ category.name }}">{{category.name}}</a>
-          <ul class="">
-            {% for child in category.children %}
-      	      <li {% if current_category.id == child.id %} class="current" {% endif %}>
-      	        <a href="{{ child.url }}" title="Categoría: {{ child.name }}">{{child.name}}</a>
-              </li>
-            {% endfor %}
-      	  </ul>
-        </li>
-      {% endfor %}
-      </ul>
-    </li>
-  </ul>
-  {% endunless %}
-
-</div>
+  {% if category.children.size != 0 %}
+    {% assign class_name = "parent_category" %}
+  {% else %}
+    {% assign class_name = "" %}
+  {% endif %}
+  
+  <li>
+    <a href="{{ category.url }}" title="Categoría: {{ category.name }}" class="{{ class_name }}">{{category.name}}</a>
+  </li>
+  
+  {% if category.children.size != 0 %}
+    {% assign categories = category.children %}
+    {% include 'sidebar' %}
+  {% endif %}
+  
+{% endfor %}

--- a/stylesheets/shop.css
+++ b/stylesheets/shop.css
@@ -360,6 +360,10 @@ li.root > a{
   color: #406DE4;
 }
 
+.parent_category {
+  font-weight: 500 !important;
+}
+
 /* ========================================= */
 /* Breadcrumbs */
 

--- a/stylesheets/shop.css
+++ b/stylesheets/shop.css
@@ -363,6 +363,9 @@ li.root > a{
 .parent_category {
   font-weight: 500 !important;
 }
+.children_list {
+  padding-left: 0.5em;
+}
 
 /* ========================================= */
 /* Breadcrumbs */

--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -15,8 +15,19 @@ File: index.liquid
       {% if keywords != nil %}
         <h3 class="search-results-title">Resultados para: <span class="search-results-keywords">{{ keywords }}</span></h3>
       {% endif %}
-
-      {% include 'sidebar' %}
+      
+      <div id="taxonomies" class="sidebar-item">
+        <h1>Catálogo</h1>
+        {% unless categories.size == 0 %}
+          <ul class="navigation-list">
+            <li><h5>Categorías</h5>
+              <ul>
+                {% include 'sidebar' %}
+              </ul>
+            </li>
+          </ul>
+        {% endunless %}
+      </div>
 
       <ul class="product-listing">
         {% for product in products %}
@@ -59,7 +70,18 @@ File: index.liquid
     {% else %}
     <div class="no-products">
       <h3 class="search-results-title">No se encontraron productos.</h3>
-      {% include 'sidebar' %}
+      <div id="taxonomies" class="sidebar-item">
+        <h1>Catálogo</h1>
+        {% unless categories.size == 0 %}
+          <ul class="navigation-list">
+            <li><h5>Categorías</h5>
+              <ul>
+                {% include 'sidebar' %}
+              </ul>
+            </li>
+          </ul>
+        {% endunless %}
+      </div>
     </div>
     {% endif %}
 


### PR DESCRIPTION
Hey @etagwerker , this PR fixes the issue https://github.com/ombulabs/ombushop/issues/1275

I just created a single PR because I want to be sure that everything is ok here before duplicate the code in the others themes.

Here is a screenshot of how it looks in the `acqua_blue` theme

![screen shot 2016-10-17 at 18 01 16](https://cloud.githubusercontent.com/assets/7442887/19455568/d5ffbcf8-9493-11e6-958c-5701a6f6add9.png)

![screen shot 2016-10-17 at 18 01 26](https://cloud.githubusercontent.com/assets/7442887/19455569/d6028942-9493-11e6-8380-4405c8e65bb8.png)

![screen shot 2016-10-17 at 18 01 45](https://cloud.githubusercontent.com/assets/7442887/19455570/d6120cf0-9493-11e6-8288-11c7be6cabba.png)

One thing that I couldn’t do was apply some margin on the children categories. I wanted to calculate a depth size for each category in order to use that value with a css class, but for some reason the `split` method doesn’t works here.

```
{% assign array = category.permalink | split: "/" %}
{% assign depth = array.size %}
```

Do you think that we should find another way to do that? any idea?
